### PR TITLE
Add transport types configuration

### DIFF
--- a/MMM-ResRobot.js
+++ b/MMM-ResRobot.js
@@ -24,6 +24,27 @@ Module.register("MMM-ResRobot",{
 		skipMinutes: 0,		// Number of minutes to skip before showing departures
 		maximumEntries: 6,	// Total Maximum Entries to show
 		truncateAfter: 5,	// A value > 0 will truncate direction name at first space after <value> characters. Default: 5
+		transportTypesMap: {
+                        "express-train": 2,
+                        "regional-train": 4,
+                        "express-bus": 8,
+                        "commuter-train": 16,
+                        "subway": 32,
+                        "tram": 64,
+                        "bus": 128,
+                        "ferry": 256
+                },
+		//Defaults to all available
+		transportTypes: [
+			"express-train",
+			"regional-train",
+			"express-bus",
+			"commuter-train",
+			"subway",
+			"tram",
+			"bus",
+			"ferry"
+		],
 		iconTable: {
 			"B": "fa fa-bus",
 			"S": "fa fa-subway",

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ uses the ResRobot API for which you do need to obtain an API key, see below.
 		position: "left",
 		header: "Departures",
 		config: {
+			transportTypes: [ //transports to include in listing, if left out then all are included
+				"bus","regional-train","express-train", "commuter-train",  
+				"express-bus", "subway", "tram", "ferry"
+			], 
 			from: "",		// ResRobot Station ID (or a comma-separated string of IDs)
 			to: "",			// ResRobot Station ID of destination (or a comma-separated string of IDs)
 			skipMinutes: 0,		// Skip departures that happens within the next <value> minutes.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ uses the ResRobot API for which you do need to obtain an API key, see below.
 
 1. Clone repository into `../modules/` inside your MagicMirror folder.
 2. Run `npm install` inside `../modules/MMM-ResRobot/` folder
-3. Find your Station ID at https://www.trafiklab.se/api/resrobot-reseplanerare/konsol. Select "Location Lookup" as Method and type your station name in "Location Name".
+3. Find your Station ID at https://www.trafiklab.se/node/14049/console. Select "Location Lookup" as Method and type your station name in "Location Name".
 4. Add the module to the MagicMirror config
 ```
 	{
@@ -26,6 +26,7 @@ uses the ResRobot API for which you do need to obtain an API key, see below.
 ```
 # Get API key
 
-You need to obtain your API key here: http://www.trafiklab.se, you want one for API "ResRobot - Pole Schedules 2". Registration is free but required.
+You need to obtain your API key here: http://www.trafiklab.se, you want one for API "ResRobot - Pole Schedules 2".
+Get it at https://www.trafiklab.se/api/resrobot-stolptidtabeller-2. Registration is free but required.
 
 


### PR DESCRIPTION
Made it easier to specify which transport-type to display by adding a getProductCode that adds the different transport types in accordance to the API docs. 

See products-parameter in the [TrafikLab ResRobot API docs](https://www.trafiklab.se/api/resrobot-stolptidtabeller-2/resrobot-stolptidtabeller-2-avgaende-trafik)