### PR TITLE
Kallelabbar

### DIFF
--- a/MMM-ResRobot.js
+++ b/MMM-ResRobot.js
@@ -191,15 +191,16 @@ Module.register("MMM-ResRobot",{
 	 * argument delay number - Milliseconds before next update. If empty, 30 seconds is used.
 	 */
 	scheduleUpdate: function(delay) {
-		var nextLoad = 30000;
+		var nextLoad = 10000;
 		if (typeof delay !== "undefined" && delay >= 0) {
 			nextLoad = delay;
 		}
 
 		var self = this;
 		clearTimeout(this.updateTimer);
-		this.updateTimer = setInterval(function() {
+		this.updateTimer = setTimeout(function() {
 			self.updateDom();
+			self.scheduleUpdate(10000);
 		}, nextLoad);
 	},
 });

--- a/node_helper.js
+++ b/node_helper.js
@@ -24,7 +24,7 @@ module.exports = NodeHelper.create({
 	// Receive notification
 	socketNotificationReceived: function(notification, payload) {
    		Log.info("node_helper for " + this.name + " received a socket notification: " + notification + " - Payload: " + JSON.stringify(payload, null, 2));
-		if (notification === "CONFIG" && this.started == false) {
+		if (notification === "CONFIG") { // && this.started == false) {
 			this.config = payload;
 			this.started = true;
 			this.departures = [];


### PR DESCRIPTION
first commit was a fix for the client side, `setInterval` with zero as a delay made it never stop calling itself. I Changed to setTimeout to have more controll.

second commit: this.started == false is not true when reloading the client, which will therefore have to wait for up to 1min before the data shows up. Same if I start headless and start the client after the server.